### PR TITLE
Fix incorrect identifiers

### DIFF
--- a/src/main/java/me/cortex/voxy/client/VoxyAbyssDebugScreenEntry.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyAbyssDebugScreenEntry.java
@@ -33,7 +33,7 @@ public class VoxyAbyssDebugScreenEntry implements DebugScreenEntry {
         if (vrs != null) {
             List<String> AbyssCoords = new ArrayList<>();
             vrs.addDebugInfo_Abyss(AbyssCoords);
-            lines.addToGroup(Identifier.fromNamespaceAndPath("voxy", "abyssCoords"), AbyssCoords);
+            lines.addToGroup(Identifier.fromNamespaceAndPath("voxy", "abyss_coords"), AbyssCoords);
         }
     }
 

--- a/src/main/java/me/cortex/voxy/client/VoxyClient.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyClient.java
@@ -84,7 +84,7 @@ public class VoxyClient implements ClientModInitializer {
             }
         });
 
-        DebugScreenEntries.register(Identifier.fromNamespaceAndPath("voxy","abyssCoords"), new VoxyAbyssDebugScreenEntry());
+        DebugScreenEntries.register(Identifier.fromNamespaceAndPath("voxy","abyss_coords"), new VoxyAbyssDebugScreenEntry());
 
         FabricLoader.getInstance()
                 .getEntrypoints("frex_flawless_frames", Consumer.class)

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinDebugScreenEntryList.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinDebugScreenEntryList.java
@@ -20,7 +20,7 @@ public abstract class MixinDebugScreenEntryList {
     private void voxy$injectVersionDisplay(CallbackInfo cir) {
         if (this.isOverlayVisible()) {
             var id0 = Identifier.fromNamespaceAndPath("voxy", "version");
-            var id1 = Identifier.fromNamespaceAndPath("voxy", "abyssCoords");
+            var id1 = Identifier.fromNamespaceAndPath("voxy", "abyss_coords");
             if (!this.currentlyEnabled.contains(id0)) {
                 this.currentlyEnabled.add(id0);
             }


### PR DESCRIPTION
Capital letters in identifiers were causing a crash because of an assertion